### PR TITLE
Note for `bid_scheme` lowercase sensivity

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -32,7 +32,7 @@ Open `example/src/env.ts` and setup your ClientID and Redirect URI
 #### Android Setup:
 1. Open `example/android` in Android studio.
 2. Open `BindidReactNativeExample/app/src/main/res/values/strings.xml`.
-3. Change `bid_scheme` and `bid_host` according to your `RedirectURI`.
+3. Change `bid_scheme` and `bid_host` according to your `RedirectURI`. Note: `bid_scheme` must be lowercase
 
 Based on the `rnbindidexample://login` example, `bid_scheme` should be `rnbindidexample` and `bid_host` should be `login`
 


### PR DESCRIPTION
while testing I figured that we can only use the lowercase name for `bid_scheme`, it did not work with camelCase or UPPERCASE