### PR TITLE
[iOS] adding 'podname' to avoid slash in spec

### DIFF
--- a/bindid-react-native.podspec
+++ b/bindid-react-native.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = package["name"]
+  s.name         = package["podfile"]
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@transmitsecurity/bindid-react-native",
+  "podfile": "bindid-react-native",
   "version": "1.0.1",
   "description": "React Native SDK for BindID SDK",
   "main": "lib/commonjs/index.js",


### PR DESCRIPTION
Fix issue with the spec name, by adding a separate field for the pod name.

CocoaPods checks if the name of spec contains `/`
https://github.dev/CocoaPods/Core/blob/master/lib/cocoapods-core/specification/linter.rb#L208-L209

In the current version (1.0.1) of SDK, spec name contains slash `@transmitsecurity/bindid-react-native`
